### PR TITLE
Final update for 4.14

### DIFF
--- a/PVS_Inventory_V41.ps1
+++ b/PVS_Inventory_V41.ps1
@@ -193,9 +193,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: PVS_Inventory_V41.ps1
-	VERSION: 4.13
+	VERSION: 4.14
 	AUTHOR: Carl Webster (with a lot of help from Michael B. Smith and Jeff Wouters)
-	LASTEDIT: February 3, 2014
+	LASTEDIT: April 1, 2014
 #>
 
 
@@ -330,7 +330,9 @@ $PSDefaultParameterValues = @{"*:Verbose"=$True}
 #Version 4.13
 #	From the vDisk Versions dialog, added the "Boot production devices from version"
 #	Added "Current booting version" after the version # for the vDisk Version used for booting
-
+#Version 4.14
+#	Save current settings for Spell Check and Grammar Check before disabling them
+#	Before closing Word, put Spelling and Grammar settings back to original
 
 Set-StrictMode -Version 2
 
@@ -1873,6 +1875,10 @@ $Word.ActiveDocument.DefaultTabStop = 36
 
 #Disable Spell and Grammar Check to resolve issue and improve performance (from Pat Coughlin)
 Write-Verbose "$(Get-Date): Disable spell checking"
+#bug reported 1-Apr-2014 by Tim Mangan
+#save current options first before turning them off
+$CurrentGrammarOption = $Word.Options.CheckGrammarAsYouType
+$CurrentSpellingOption = $Word.Options.CheckSpellingAsYouType
 $Word.Options.CheckGrammarAsYouType = $False
 $Word.Options.CheckSpellingAsYouType = $False
 
@@ -4624,6 +4630,11 @@ If($CoverPagesExist)
 	#update the Table of Contents
 	$doc.TablesOfContents.item(1).Update()
 }
+
+#bug fix 1-Apr-2014
+#reset Grammar and Spelling options back to their original settings
+$Word.Options.CheckGrammarAsYouType = $CurrentGrammarOption
+$Word.Options.CheckSpellingAsYouType = $CurrentSpellingOption
 
 Write-Verbose "$(Get-Date): Save and Close document and Shutdown Word"
 If($WordVersion -eq $wdWord2007)


### PR DESCRIPTION
#Version 4.14
#	Save current settings for Spell Check and Grammar Check before disabling them
#	Before closing Word, put Spelling and Grammar settings back to original