### PR TITLE
Final update for 4.292

### DIFF
--- a/PVS_Inventory_V42.ps1
+++ b/PVS_Inventory_V42.ps1
@@ -3,12 +3,15 @@
 
 <#
 .SYNOPSIS
-	Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word 2010, 2013, or 2016.
+	Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word 
+	2010, 2013, or 2016.
 .DESCRIPTION
-	Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word and PowerShell.
+	Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word 
+	and PowerShell.
 	Creates a Word document named after the PVS 5.x, 6.x or 7.x farm.
 	Document includes a Cover Page, Table of Contents and Footer.
-	Version 4 and later include support for the following language versions of Microsoft Word:
+	Version 4 and later include support for the following language versions of Microsoft 
+	Word:
 		Catalan
 		Chinese
 		Danish
@@ -24,12 +27,13 @@
 
 .PARAMETER CompanyName
 	Company Name to use for the Cover Page.  
-	Default value is contained in HKCU:\Software\Microsoft\Office\Common\UserInfo\CompanyName or
-	HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated on the 
-	computer running the script.
+	Default value is contained in 
+	HKCU:\Software\Microsoft\Office\Common\UserInfo\CompanyName or
+	HKCU:\Software\Microsoft\Office\Common\UserInfo\Company, whichever is populated 
+	on the computer running the script.
 	This parameter has an alias of CN.
-	If either registry key does not exist and this parameter is not specified, the report will
-	not contain a Company Name on the cover page.
+	If either registry key does not exist and this parameter is not specified, the report 
+	will not contain a Company Name on the cover page.
 	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
@@ -40,9 +44,9 @@
 		Alphabet (Word 2010. Works)
 		Annual (Word 2010. Doesn't work well for this report)
 		Austere (Word 2010. Works)
-		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly works in 2010 but 
-						Subtitle/Subject & Author fields need to be moved 
-						after title box is moved up)
+		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
+		works in 2010 but Subtitle/Subject & Author fields need to be moved 
+		after title box is moved up)
 		Banded (Word 2013/2016. Works)
 		Conservative (Word 2010. Works)
 		Contrast (Word 2010. Works)
@@ -52,20 +56,22 @@
 		Filigree (Word 2013/2016. Works)
 		Grid (Word 2010/2013/2016. Works in 2010)
 		Integral (Word 2013/2016. Works)
-		Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font 
-						changed to 8 point)
-		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be manually resized or font 
-						changed to 8 point)
+		Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
+		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
+		manually resized or font changed to 8 point)
 		Mod (Word 2010. Works)
-		Motion (Word 2010/2013/2016. Works if top date is manually changed to 36 point)
+		Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+		36 point)
 		Newsprint (Word 2010. Works but date is not populated)
 		Perspective (Word 2010. Works)
 		Pinstripes (Word 2010. Works)
-		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized or font 
-					changed to 14 point)
+		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
+		resized or font changed to 14 point)
 		Retrospect (Word 2013/2016. Works)
 		Semaphore (Word 2013/2016. Works)
-		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 2010)
+		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+		2010)
 		Slice (Dark) (Word 2013/2016. Doesn't work)
 		Slice (Light) (Word 2013/2016. Doesn't work)
 		Stacks (Word 2010. Works)
@@ -161,8 +167,10 @@
 .EXAMPLE
 	PS C:\PSScript > .\PVS_Inventory_V42.ps1 -Hardware 
 	
-	Will use all Default values and add additional information for each server about its hardware.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	Will use all Default values and add additional information for each server about its 
+	hardware.
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -170,14 +178,16 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CompanyName "Carl Webster Consulting" -CoverPage "Mod" -UserName "Carl Webster"
+	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CompanyName "Carl Webster Consulting" 
+	-CoverPage "Mod" -UserName "Carl Webster"
 
 	Will use:
 		Carl Webster Consulting for the Company Name.
 		Mod for the Cover Page format.
 		Carl Webster for the User Name.
 .EXAMPLE
-	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster" -AdminAddress PVS1
+	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" 
+	-UN "Carl Webster" -AdminAddress PVS1
 
 	Will use:
 		Carl Webster Consulting for the Company Name (alias CN).
@@ -185,7 +195,9 @@
 		Carl Webster for the User Name (alias UN).
 		PVS1 for AdminAddress.
 .EXAMPLE
-	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password Abc123!@#
+	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" 
+	-UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password 
+	Abc123!@#
 
 	Will use:
 		Carl Webster Consulting for the Company Name (alias CN).
@@ -196,7 +208,8 @@
 		WebstersLab for Domain.
 		Abc123!@# for Password.
 .EXAMPLE
-	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN "Carl Webster" -AdminAddress PVS1 -User cwebster
+	PS C:\PSScript .\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" 
+	-UN "Carl Webster" -AdminAddress PVS1 -User cwebster
 
 	Will use:
 		Carl Webster Consulting for the Company Name (alias CN).
@@ -219,10 +232,12 @@
 	LocalHost for AdminAddress.
 	Will return all Audit Trail entries from "01/01/2020" through "01/31/2020".
 .EXAMPLE
-	PS C:\PSScript > .\PVS_Inventory_V42.ps1 -AdminAddress PVS1 -Folder \\FileServer\ShareName
+	PS C:\PSScript > .\PVS_Inventory_V42.ps1 -AdminAddress PVS1 -Folder 
+	\\FileServer\ShareName
 	
 	Will use all default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
 	$env:username = Administrator
 
@@ -233,44 +248,103 @@
 	
 	Output file will be saved in the path \\FileServer\ShareName
 .EXAMPLE
-	PS C:\PSScript > .\PVS_Inventory_V42.ps1 -AdminAddress PVS1 -SmtpServer mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName DHCPServer01
-	
-	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	$env:username = Administrator
+	PS C:\PSScript > .\PVS_Inventory_V42.ps1 
+	-SmtpServer mail.domain.tld
+	-From XDAdmin@domain.tld 
+	-To ITGroup@domain.tld	
 
-	Carl Webster for the Company Name.
-	Sideline for the Cover Page format.
-	Administrator for the User Name.
-	PVS1 for AdminAddress.
-	
-	Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, sending to ITGroup@domain.tld.
-	If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, 
+	sending to ITGroup@domain.tld.
+
+	The script will use the default SMTP port 25 and will not use SSL.
+
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
 .EXAMPLE
-	PS C:\PSScript > .\PVS_Inventory_V42.ps1 -AdminAddress PVS1 -ComputerName DHCPServer01 -SmtpServer smtp.office365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
-	
-	Will use all Default values.
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl Webster" or
-	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
-	$env:username = Administrator
+	PS C:\PSScript > .\PVS_Inventory_V42.ps1 
+	-SmtpServer mailrelay.domain.tld
+	-From Anonymous@domain.tld 
+	-To ITGroup@domain.tld	
 
-	Carl Webster for the Company Name.
-	Sideline for the Cover Page format.
-	Administrator for the User Name.
-	PVS1 for AdminAddress.
+	***SENDING UNAUTHENTICATED EMAIL***
+
+	The script will use the email server mailrelay.domain.tld, sending from 
+	anonymous@domain.tld, sending to ITGroup@domain.tld.
+
+	To send unauthenticated email using an email relay server requires the From email account 
+	to use the name Anonymous.
+
+	The script will use the default SMTP port 25 and will not use SSL.
 	
-	Script will use the email server smtp.office365.com on port 587 using SSL, sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-	If the current user's credentials are not valid to send email, the user will be prompted to enter valid credentials.
+	***GMAIL/G SUITE SMTP RELAY***
+	https://support.google.com/a/answer/2956491?hl=en
+	https://support.google.com/a/answer/176600?hl=en
+
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	***GMAIL/G SUITE SMTP RELAY***
+
+	The script will generate an anonymous secure password for the anonymous@domain.tld 
+	account.
+.EXAMPLE
+	PS C:\PSScript > .\PVS_Inventory_V42.ps1 
+	-SmtpServer labaddomain-com.mail.protection.outlook.com
+	-UseSSL
+	-From SomeEmailAddress@labaddomain.com 
+	-To ITGroupDL@labaddomain.com	
+
+	***OFFICE 365 Example***
+
+	https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
+	
+	This uses Option 2 from the above link.
+	
+	***OFFICE 365 Example***
+
+	The script will use the email server labaddomain-com.mail.protection.outlook.com, 
+	sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+
+	The script will use the default SMTP port 25 and will use SSL.
+.EXAMPLE
+	PS C:\PSScript > .\PVS_Inventory_V42.ps1 
+	-SmtpServer smtp.office365.com 
+	-SmtpPort 587
+	-UseSSL 
+	-From Webster@CarlWebster.com 
+	-To ITGroup@CarlWebster.com	
+
+	The script will use the email server smtp.office365.com on port 587 using SSL, 
+	sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
+.EXAMPLE
+	PS C:\PSScript > .\PVS_Inventory_V42.ps1 
+	-SmtpServer smtp.gmail.com 
+	-SmtpPort 587
+	-UseSSL 
+	-From Webster@CarlWebster.com 
+	-To ITGroup@CarlWebster.com	
+
+	*** NOTE ***
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	*** NOTE ***
+	
+	The script will use the email server smtp.gmail.com on port 587 using SSL, 
+	sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+
+	If the current user's credentials are not valid to send email, 
+	the user will be prompted to enter valid credentials.
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: PVS_Inventory_V42.ps1
-	VERSION: 4.291
+	VERSION: 4.292
 	AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters and Iain Brighton)
-	LASTEDIT: December 17, 2019
+	LASTEDIT: May 10, 2020
 #>
 
 
@@ -279,11 +353,9 @@
 
 Param(
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$MSWord=$False,
 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$PDF=$False,
 
 	[parameter(Mandatory=$False)] 
@@ -316,38 +388,35 @@ Param(
 	
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Alias("CN")]
 	[ValidateNotNullOrEmpty()]
 	[string]$CompanyName="",
     
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Alias("CP")]
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Alias("UN")]
 	[ValidateNotNullOrEmpty()]
 	[string]$UserName=$env:username,
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
+	[parameter(Mandatory=$False)] 
 	[string]$SmtpServer="",
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[parameter(Mandatory=$False)] 
 	[int]$SmtpPort=25,
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[parameter(Mandatory=$False)] 
 	[switch]$UseSSL=$False,
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
+	[parameter(Mandatory=$False)] 
 	[string]$From="",
 
-	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
+	[parameter(Mandatory=$False)] 
 	[string]$To=""
 	
 	)
@@ -360,6 +429,17 @@ Param(
 #This script written for "Benji", March 19, 2012
 #Thanks to Michael B. Smith, Joe Shonk and Stephane Thirion for testing and fine-tuning tips 
 
+#Version 4.292 10-May-2020
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
+#	Remove the SMTP parameterset and manually verify the parameters
+#	Update Function SendEmail to handle anonymous unauthenticated email
+#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+#	Update Help Text
+#
 #Version 4.291 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -477,7 +557,15 @@ Else
 		Write-Verbose "$(Get-Date): MSWord is $($MSWord)"
 		Write-Verbose "$(Get-Date): PDF is $($PDF)"
 	}
-	Write-Error "Unable to determine output parameter.  Script cannot continue"
+	Write-Error "
+	`n`n
+	`t`t
+	Unable to determine output parameter.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 
@@ -496,16 +584,105 @@ If($Folder -ne "")
 		Else
 		{
 			#it exists but it is a file not a folder
-			Write-Error "Folder $Folder is a file, not a folder.  Script cannot continue"
+			Write-Error "
+			`n`n
+			`t`t
+			Folder $Folder is a file, not a folder.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 	}
 	Else
 	{
 		#does not exist
-		Write-Error "Folder $Folder does not exist.  Script cannot continue"
+		Write-Error "
+		`n`n
+		`t`t
+		Folder $Folder does not exist.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
+}
+
+If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($From) -and [String]::IsNullOrEmpty($To))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified an SmtpServer but did not include a From or To email address.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($From) -and ![String]::IsNullOrEmpty($To))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified an SmtpServer and a To email address but did not include a From email address.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($To) -and ![String]::IsNullOrEmpty($From))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified an SmtpServer and a From email address but did not include a To email address.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($From) -and ![String]::IsNullOrEmpty($To) -and [String]::IsNullOrEmpty($SmtpServer))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified From and To email addresses but did not include the SmtpServer.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($From) -and [String]::IsNullOrEmpty($SmtpServer))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified a From email address but did not include the SmtpServer.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
+}
+If(![String]::IsNullOrEmpty($To) -and [String]::IsNullOrEmpty($SmtpServer))
+{
+	Write-Error "
+	`n`n
+	`t`t
+	You specified a To email address but did not include the SmtpServer.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n"
+	Exit
 }
 
 [string]$Script:RunningOS = (Get-WmiObject -class Win32_OperatingSystem -EA 0).Caption
@@ -520,8 +697,8 @@ If($MSWord -or $PDF)
 	#http://groovy.codehaus.org/modules/scriptom/1.6.0/scriptom-office-2K3-tlb/apidocs/
 	#http://msdn.microsoft.com/en-us/library/office/aa211923(v=office.11).aspx
 	[int]$wdAlignPageNumberRight = 2
-	[long]$wdColorGray15 = 14277081
-	[long]$wdColorGray05 = 15987699 
+	[int]$wdColorGray15 = 14277081
+	[int]$wdColorGray05 = 15987699 
 	[int]$wdMove = 0
 	[int]$wdSeekMainDocument = 0
 	[int]$wdSeekPrimaryFooter = 4
@@ -580,70 +757,123 @@ If($MSWord -or $PDF)
 #region email function
 Function SendEmail
 {
-	Param([string]$Attachments)
+	Param([array]$Attachments)
 	Write-Verbose "$(Get-Date): Prepare to email"
+
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
 	$emailBody = @"
 Hello, <br />
 <br />
 $Script:Title is attached.
+
 "@ 
 
+	If($Dev)
+	{
+		Out-File -FilePath $Script:DevErrorFile -InputObject $error 4>$Null
+	}
+
 	$error.Clear()
-	If($UseSSL)
+	
+	If($From -Like "anonymous@*")
 	{
-		Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-		-UseSSL *>$Null
-	}
-	Else
-	{
-		Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
-	}
+		#https://serverfault.com/questions/543052/sending-unauthenticated-mail-through-ms-exchange-with-powershell-windows-server
+		$anonUsername = "anonymous"
+		$anonPassword = ConvertTo-SecureString -String "anonymous" -AsPlainText -Force
+		$anonCredentials = New-Object System.Management.Automation.PSCredential($anonUsername,$anonPassword)
 
-	$e = $error[0]
-
-	If($e.Exception.ToString().Contains("5.7.57"))
-	{
-		#The server response was: 5.7.57 SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-		Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
-
-		$emailCredentials = Get-Credential -Message "Enter the email account and password to send email"
-
-		$error.Clear()
 		If($UseSSL)
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-UseSSL -credential $emailCredentials *>$Null 
+			-UseSSL -credential $anonCredentials *>$Null 
 		}
 		Else
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-credential $emailCredentials *>$Null 
+			-credential $anonCredentials *>$Null 
 		}
-
-		$e = $error[0]
-
-		If($? -and $Null -eq $e)
+		
+		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+			Write-Verbose "$(Get-Date): Email successfully sent using anonymous credentials"
 		}
-		Else
+		ElseIf(!$?)
 		{
+			$e = $error[0]
+
 			Write-Verbose "$(Get-Date): Email was not sent:"
 			Write-Warning "$(Get-Date): Exception: $e.Exception" 
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): Email was not sent:"
-		Write-Warning "$(Get-Date): Exception: $e.Exception" 
+		If($UseSSL)
+		{
+			Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+			-UseSSL *>$Null
+		}
+		Else
+		{
+			Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
+		}
+
+		If(!$?)
+		{
+			$e = $error[0]
+			
+			#error 5.7.57 is O365 and error 5.7.0 is gmail
+			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
+			{
+				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
+				Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
+
+				If($Dev)
+				{
+					Out-File -FilePath $Script:DevErrorFile -InputObject $error -Append 4>$Null
+				}
+
+				$error.Clear()
+
+				$emailCredentials = Get-Credential -UserName $From -Message "Enter the password to send email"
+
+				If($UseSSL)
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-UseSSL -credential $emailCredentials *>$Null 
+				}
+				Else
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-credential $emailCredentials *>$Null 
+				}
+
+				If($?)
+				{
+					Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+				}
+				ElseIf(!$?)
+				{
+					$e = $error[0]
+
+					Write-Verbose "$(Get-Date): Email was not sent:"
+					Write-Warning "$(Get-Date): Exception: $e.Exception" 
+				}
+			}
+			Else
+			{
+				Write-Verbose "$(Get-Date): Email was not sent:"
+				Write-Warning "$(Get-Date): Exception: $e.Exception" 
+			}
+		}
 	}
 }
 #endregion
@@ -874,7 +1104,7 @@ Function GetComputerWMIInfo
 				
 				If($? -and $Null -ne $ThisNic)
 				{
-					OutputNicItem $Nic $ThisNic
+					OutputNicItem $Nic $ThisNic $RemoteComputerName
 				}
 				ElseIf(!$?)
 				{
@@ -1187,9 +1417,9 @@ Function OutputProcessorItem
 
 Function OutputNicItem
 {
-	Param([object]$Nic, [object]$ThisNic)
+	Param([object]$Nic, [object]$ThisNic, [string]$RemoteComputerName)
 	
-	$powerMgmt = Get-WmiObject MSPower_DeviceEnable -Namespace root\wmi | Where-Object {$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	$powerMgmt = Get-WmiObject -computername $RemoteComputerName MSPower_DeviceEnable -Namespace root\wmi | Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
 
 	If($? -and $Null -ne $powerMgmt)
 	{
@@ -1208,26 +1438,48 @@ Function OutputNicItem
 	}
 	
 	$xAvailability = ""
-	Switch ($processor.availability)
+	Switch ($ThisNic.availability)
 	{
-		1	{$xAvailability = "Other"; Break }
-		2	{$xAvailability = "Unknown"; Break }
-		3	{$xAvailability = "Running or Full Power"; Break }
-		4	{$xAvailability = "Warning"; Break }
-		5	{$xAvailability = "In Test"; Break }
-		6	{$xAvailability = "Not Applicable"; Break }
-		7	{$xAvailability = "Power Off"; Break }
-		8	{$xAvailability = "Off Line"; Break }
-		9	{$xAvailability = "Off Duty"; Break }
-		10	{$xAvailability = "Degraded"; Break }
-		11	{$xAvailability = "Not Installed"; Break }
-		12	{$xAvailability = "Install Error"; Break }
-		13	{$xAvailability = "Power Save - Unknown"; Break }
-		14	{$xAvailability = "Power Save - Low Power Mode"; Break }
-		15	{$xAvailability = "Power Save - Standby"; Break }
-		16	{$xAvailability = "Power Cycle"; Break }
-		17	{$xAvailability = "Power Save - Warning"; Break }
-		Default	{$xAvailability = "Unknown"; Break }
+		1		{$xAvailability = "Other"; Break}
+		2		{$xAvailability = "Unknown"; Break}
+		3		{$xAvailability = "Running or Full Power"; Break}
+		4		{$xAvailability = "Warning"; Break}
+		5		{$xAvailability = "In Test"; Break}
+		6		{$xAvailability = "Not Applicable"; Break}
+		7		{$xAvailability = "Power Off"; Break}
+		8		{$xAvailability = "Off Line"; Break}
+		9		{$xAvailability = "Off Duty"; Break}
+		10		{$xAvailability = "Degraded"; Break}
+		11		{$xAvailability = "Not Installed"; Break}
+		12		{$xAvailability = "Install Error"; Break}
+		13		{$xAvailability = "Power Save - Unknown"; Break}
+		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15		{$xAvailability = "Power Save - Standby"; Break}
+		16		{$xAvailability = "Power Cycle"; Break}
+		17		{$xAvailability = "Power Save - Warning"; Break}
+		Default	{$xAvailability = "Unknown"; Break}
+	}
+
+	#attempt to get Receive Side Scaling setting
+	$RSSEnabled = "N/A"
+	Try
+	{
+		#https://ios.developreference.com/article/10085450/How+do+I+enable+VRSS+(Virtual+Receive+Side+Scaling)+for+a+Windows+VM+without+relying+on+Enable-NetAdapterRSS%3F
+		$RSSEnabled = (Get-WmiObject -ComputerName $RemoteComputerName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0).Enabled
+
+		If($RSSEnabled)
+		{
+			$RSSEnabled = "Enabled"
+		}
+		Else
+		{
+			$RSSEnabled = "Disabled"
+		}
+	}
+	
+	Catch
+	{
+		$RSSEnabled = "Not available on $Script:RunningOS"
 	}
 
 	$xIPAddress = @()
@@ -1304,6 +1556,7 @@ Function OutputNicItem
 		$NicInformation += @{ Data = "Availability"; Value = $xAvailability; }
 		$NicInformation += @{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }
 		$NicInformation += @{ Data = "Physical Address"; Value = $Nic.macaddress; }
+		$NicInformation += @{ Data = "Receive Side Scaling"; Value = $RSSEnabled; }
 		If($xIPAddress.Count -gt 1)
 		{
 			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress[0]; }
@@ -2448,7 +2701,7 @@ Function SetWordCellFormat
 		# Font size
 		[Parameter()] [ValidateNotNullOrEmpty()] [int] $Size = 0,
 		# Cell background color
-		[Parameter()] [AllowNull()] $BackgroundColor = $null,
+		[Parameter()] [AllowNull()] [int]$BackgroundColor = $null,
 		# Force solid background color
 		[Switch] $Solid,
 		[Switch] $Bold,
@@ -2639,7 +2892,15 @@ Function SetupWord
 	{
 		Write-Warning "The Word object could not be created.  You may need to repair your Word installation."
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tThe Word object could not be created.  You may need to repair your Word installation.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		The Word object could not be created.  You may need to repair your Word installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
 
@@ -2656,7 +2917,15 @@ Function SetupWord
 	If(!($Script:WordLanguageValue -gt -1))
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tUnable to determine the Word language value.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Unable to determine the Word language value.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 	Write-Verbose "$(Get-Date): Word language value is $($Script:WordLanguageValue)"
@@ -2681,13 +2950,45 @@ Function SetupWord
 	ElseIf($Script:WordVersion -eq $wdWord2007)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tMicrosoft Word 2007 is no longer supported.`n`n`t`tScript will end.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Microsoft Word 2007 is no longer supported.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		"
 		AbortScript
+	}
+	ElseIf($Script:WordVersion -eq 0)
+	{
+		Write-Error "
+		`n`n
+		`t`t
+		The Word Version is 0. You should run a full online repair of your Office installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
+		Exit
 	}
 	Else
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tYou are running an untested or unsupported version of Microsoft Word.`n`n`t`tScript will end.`n`n`t`tPlease send info on your version of Word to webster@carlwebster.com`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		You are running an untested or unsupported version of Microsoft Word.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		`t`t
+		Please send info on your version of Word to webster@carlwebster.com
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -2829,7 +3130,15 @@ Function SetupWord
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Verbose "$(Get-Date): Word language value $($Script:WordLanguageValue)"
 		Write-Verbose "$(Get-Date): Culture code $($Script:WordCultureCode)"
-		Write-Error "`n`n`t`tFor $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		For $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -2892,7 +3201,15 @@ Function SetupWord
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn empty Word document could not be created.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An empty Word document could not be created.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -2901,7 +3218,15 @@ Function SetupWord
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn unknown error happened selecting the entire Word document for default formatting options.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An unknown error happened selecting the entire Word document for default formatting options.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3164,7 +3489,15 @@ Write-Verbose "$(Get-Date): Checking for McliPSSnapin"
 If(!(Check-NeededPSSnapins "McliPSSnapIn")){
 	#We're missing Citrix Snapins that we need
 	$ErrorActionPreference = $SaveEAPreference
-	Write-Error "Missing Citrix PowerShell Snap-ins Detected, check the console above for more information. Script will now close."
+	Write-Error "
+	`n`n
+	`t`t
+	Missing Citrix PowerShell Snap-ins Detected, check the console above for more information.
+	`n`n
+	`t`t
+	Script will now close.
+	`n`n
+	"
 	Exit
 }
 
@@ -3275,7 +3608,15 @@ If($soapserver.Status -ne "Running")
 	{
 		Write-Warning "The Citrix PVS Soap Server service is not Started"
 	}
-	Write-Error "Script cannot continue.  See message above."
+	Write-Error "
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n
+	`t`t
+	See message above.
+	`n`n
+	"
 	Exit
 }
 
@@ -3290,7 +3631,15 @@ If($StreamService.Status -ne "Running")
 	{
 		Write-Warning "The Citrix PVS Stream Service service is not Started"
 	}
-	Write-Error "Script cannot continue.  See message above."
+	Write-Error "
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n
+	`t`t
+	See message above.
+	`n`n
+	"
 	Exit
 }
 
@@ -3323,7 +3672,12 @@ Else
 	{
 		Write-Warning "Error(s) returned: " $error[$x]
 	}
-	Write-Error "Script is terminating"
+	Write-Error "
+	`n`n
+	`t`t
+	Script is terminating.
+	`n`n
+	"
 	#without version info, script should not proceed
 	Exit
 }
@@ -3346,7 +3700,15 @@ If($Farm -eq $Null)
 {
 	#without farm info, script should not proceed
 	$ErrorActionPreference = $SaveEAPreference
-	Write-Error "PVS Farm information could not be retrieved.  Script is terminating."
+	Write-Error "
+	`n`n
+	`t`t
+	PVS Farm information could not be retrieved.
+	`n`n
+	`t`t
+	Script is terminating.
+	`n`n
+	"
 	Exit
 }
 

--- a/PVS_Inventory_V42_ReadMe.rtf
+++ b/PVS_Inventory_V42_ReadMe.rtf
@@ -1,19 +1,19 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f64\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f65\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
-{\f67\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f68\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f69\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f70\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
-{\f71\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f72\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
-{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
-{\f414\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f415\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f417\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f418\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\f419\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f420\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f421\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f422\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
-{\f474\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f475\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f477\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f478\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
-{\f481\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f482\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f540\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f541\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f543\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f544\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f545\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f546\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f547\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f548\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f560\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f561\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}
+{\f563\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}{\f564\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f565\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f566\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}
+{\f567\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}{\f568\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f880\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f881\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}
+{\f883\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f884\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f887\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f888\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}
+{\f910\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}{\f911\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\f913\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\f914\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
+{\f915\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\f916\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\f917\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}{\f918\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}
+{\f970\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f971\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f973\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\f974\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
+{\f977\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f978\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -35,8 +35,8 @@
 {\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
 {\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
 {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\chyperlink\ctint255\cshade255\red0\green0\blue255;\red54\green95\blue145;\red79\green129\blue189;}
-{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
+\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\chyperlink\ctint255\cshade255\red0\green0\blue255;\red96\green94\blue92;\red225\green223\blue221;
+\red54\green95\blue145;\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
 \ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{
 \s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
 heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
@@ -46,88 +46,92 @@ heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\li
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext17 \sqformat \spriority1 \styrsid14894181 No Spacing;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \sunhideused \styrsid14894181 
-Hyperlink;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 
-\af0 \ltrch\fcs0 \fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fbias0 \fi-720\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li6480\lin6480 }{\listname ;}\listid314996233}{\list\listtemplateid-1236917028\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 
-\fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid558714133}{\list\listtemplateid-990473222\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 
-\fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid642077380}{\list\listtemplateid1184951006\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
-\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23
-\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid676005662}{\list\listtemplateid-546045730\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2520\lin2520 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3240\lin3240 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3960\lin3960 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4680\lin4680 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5400\lin5400 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li6120\lin6120 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6840\lin6840 }{\listname ;}\listid872425844}{\list\listtemplateid1500158440\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1217358328}{\list\listtemplateid1020826486\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
-\levelstartat0\levelspace360\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
-\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel
-\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}
-{\list\listtemplateid-1055998564\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}
-{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380
-\listoverridecount0\ls8}}{\*\rsidtbl \rsid2246377\rsid2512671\rsid2584501\rsid2585069\rsid3085909\rsid4090611\rsid4482658\rsid6383267\rsid6900725\rsid7282308\rsid9196948\rsid9714737\rsid9768283\rsid11218240\rsid12087820\rsid12282547\rsid13253201
-\rsid14894181\rsid15221399\rsid15890753\rsid16711874}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}
-{\revtim\yr2019\mo12\dy17\hr11\min35}{\version15}{\edmins89}{\nofpages12}{\nofwords3343}{\nofchars19060}{\nofcharsws22359}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid288586 Unresolved Mention;}}{\*\listtable{\list\listtemplateid-1612023500\listhybrid{\listlevel\levelnfc0\levelnfcn0
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid1670146738\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid314996233}
+{\list\listtemplateid-1236917028\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 
+\fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid558714133}{\list\listtemplateid-990473222\listhybrid{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid642077380}{\list\listtemplateid1184951006\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
+\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689
+\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers
+;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
+\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid676005662}{\list\listtemplateid-546045730\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1800\lin1800 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2520\lin2520 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3240\lin3240 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3960\lin3960 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4680\lin4680 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5400\lin5400 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li6120\lin6120 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6840\lin6840 }{\listname ;}\listid872425844}{\list\listtemplateid1500158440\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid-1088912668\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0\hres0\chhres0 \fi-720\li1080\lin1080 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid1217358328}{\list\listtemplateid1020826486
+\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace360\levelindent0{\leveltext\leveltemplateid1732811676\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 
+\fi-720\li1080\lin1080 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1940482595}{\list\listtemplateid-1055998564\listhybrid{\listlevel\levelnfc0\levelnfcn0
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0
+\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2
+\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}
+{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662\listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}
+{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}{\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}}{\*\rsidtbl \rsid288586\rsid2246377
+\rsid2512671\rsid2584501\rsid2585069\rsid3085909\rsid4090611\rsid4482658\rsid6383267\rsid6900725\rsid7282308\rsid9196948\rsid9714737\rsid9768283\rsid11218240\rsid12087820\rsid12282547\rsid13253201\rsid14894181\rsid15221399\rsid15890753\rsid16711874}
+{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2020\mo5\dy10\hr13\min59}{\version16}{\edmins97}
+{\nofpages13}{\nofwords3457}{\nofchars19711}{\nofcharsws23122}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDYyNjYzNDCyNLCwNDc3MjZV0lEKTi0uzszPAykwrAUAdVY53CwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 PVS Version 4.}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
-\b\fs28\cf20\insrsid4090611 \hich\af43\dbch\af31505\loch\f43 2}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid2585069 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf22\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 PVS Version 4.}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
+\b\fs28\cf22\insrsid4090611 \hich\af43\dbch\af31505\loch\f43 2}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf22\insrsid2585069 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid2585069 
 \par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 NOTE: This script }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid4090611\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 
@@ -135,7 +139,7 @@ requires }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid224
 or later}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid2246377 .
 \par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid4090611\charrsid2246377 \hich\af31506\dbch\af31505\loch\f31506 NOTE: Word 2007 is no longer supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 \f31506\insrsid4090611\charrsid2246377 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 One of the most requested features added to Version 4 was support for non-English versions of Microsoft Word.  The script supports the following languages:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid2585069\charrsid13253201 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar
@@ -156,7 +160,7 @@ or later}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f31506\insrsid2585069\charrsid2246
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid2585069\charrsid13253201 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Swedish
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14894181 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid2585069 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14894181 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid2585069 
 \hich\af43\dbch\af31505\loch\f43 Prerequisites
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 
 Before we can start using PowerShell to document anything in the PVS farm, let us ensure we have the necessary requirements.
@@ -204,7 +208,7 @@ McliPSSnapIn.dll"}{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \b\f31506\fs22\insrsid
 \par }{\rtlch\fcs1 \ab\af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Note: }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 If you are r\hich\af37\dbch\af31505\loch\f37 
 unning 64-bit Windows Server, you will need to run both commands so the snap-in is registered for both 32-bit and 64-bit PowerShell.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 Script Usage
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid2585069 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 How to use this script?
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2585069\charrsid13253201 \hich\af31506\dbch\af31505\loch\f31506 1.\tab}}\pard \ltrpar
@@ -228,18 +232,18 @@ PDF option, a PDF file is created named after the PVS Farm.}{\rtlch\fcs1 \af0\af
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 To run the script remotely, please read the following article}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 s}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 :
-\par }{\field{\*\fldinst {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181\charrsid14894181 \hich\af37\dbch\af31505\loch\f37 
-http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13253201 
-{\*\datafield 
+\par }{\field{\*\fldinst {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181\charrsid14894181 \hich\af37\dbch\af31505\loch\f37 http://ca
+\hich\af37\dbch\af31505\loch\f37 rlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13253201 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bcc00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d0070007600
 73002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000075002800
-002001004f}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect
-\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
+002001004f00}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 http://ca\hich\af37\dbch\af31505\loch\f37 
+rlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e007400610074006900
-6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000b40000429a0061}}}{\fldrslt {\rtlch\fcs1 
+6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000b40000429a006100}}}{\fldrslt {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
@@ -247,7 +251,7 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \ltrch\fcs0 \f37\fs22\insrsid4090611 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0a01000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f0076006900
 730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d0061
-006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000004000000003f46}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 
+006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000004000000003f4600}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 
 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
@@ -257,76 +261,48 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par \hich\af37\dbch\af31505\loch\f37 I have tested this script with PVS 5.6 SP3, PVS 6.0, PVS 6.1, PVS 7.0 and PVS 7.1.  I have tested the script running on and from Windows 7, Windows 8}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 
 \hich\af37\dbch\af31505\loch\f37 .x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 , Server 2003 R2, Server 2008 R2, Server 2012 \hich\af37\dbch\af31505\loch\f37 and Server 2012 R2.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid15221399 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15221399 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid15221399 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15221399 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid15221399 
 \hich\af43\dbch\af31505\loch\f43 Help Text
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15221399 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 NAME
-\par }\pard\plain \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15221399 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_Inventory_V42.ps1
+\par }\pard\plain \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid288586 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\PVS_Inventory_V42.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 2010}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 \hich\af2\dbch\af31505\loch\f2 , }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 2013}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 \hich\af2\dbch\af31505\loch\f2  or 2016}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399\charrsid15221399 .
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 2010, 2013, or 2016.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V42.ps1 [-MSWord] [-Hardware] [-StartDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-AdminAddress <String>] [-Domain <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-User <String>] [-Password <String>] [-Folder}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-CoverPage\hich\af2\dbch\af31505\loch\f2  <String>] [-UserName <String>] [<CommonParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_Inventory_V42.ps1 [-MSWord] [-PDF] [-Text] [-HTML] [-Hardware] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-AddDateTime] [-AdminAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\PVS_Inventory_V42.ps1 [-MSWord] [-Hardware] [-StartDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  }
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-AdminAdd\hich\af2\dbch\af31505\loch\f2 ress <String>] [-Domain <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-Domain <String>] [-Use\hich\af2\dbch\af31505\loch\f2 r <String>] [-Password <String>]}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CoverPage <String>] [-UserName <String>] -SmtpServer }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <String>}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-\hich\af2\dbch\af31505\loch\f2 SmtpPort <Int32>] [-UseSSL] -From <String> -To <String> }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-User <String>] [-Password <String>] [-Folder}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-SmtpServer <String>] [-SmtpPort
+\par \hich\af2\dbch\af31505\loch\f2     <Int32>] [-UseSSL] [-From <String>] [-To <String>] [<Com\hich\af2\dbch\af31505\loch\f2 monParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_Inventory_V42.ps1 [-PDF] [-Hardware] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password <String>] [-Folder <String>] [-CompanyName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [<CommonParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_Inventory_V42.ps1 [-Text] [-Hardware] [-StartDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>]\hich\af2\dbch\af31505\loch\f2  [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Domain <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-User <String>] [-Password <String>] [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\PVS_Inventory_V42.ps1 [-HTML] [-Hardware] [-StartDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-EndDate <DateTime>] [-Ad\hich\af2\dbch\af31505\loch\f2 dDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Domain <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [-User <String>] [-Password <String>] [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\PSScript\\PVS_Inventory_V42.ps1 [-PDF] [-Hardware] [-StartDate <DateTime>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2  [-EndDate <DateTime>] [-AddDateTime]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-AdminAddress <String>] [-Domain <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-User <String>] [-Password <String>] [-Folder <String>] [-CompanyName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-SmtpServer <String>] [-SmtpPort <Int32>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] [-From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 and Powe\hich\af2\dbch\af31505\loch\f2 rShell.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using M\hich\af2\dbch\af31505\loch\f2 icrosoft Word }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 and PowerShell.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word document named after the PVS 5.x, 6.x or 7.x farm.
 \par \hich\af2\dbch\af31505\loch\f2     Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Version 4 and later include support for the following language versions of Microsoft }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Word:
-\par \hich\af2\dbch\af31505\loch\f2         Cata\hich\af2\dbch\af31505\loch\f2 lan}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 \tab \hich\af2\dbch\af31505\loch\f2  Chinese}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948\charrsid15221399 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2         Danish
+\par \hich\af2\dbch\af31505\loch\f2     Version 4 and later include support for the following language versions of Microsoft }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 W\hich\af2\dbch\af31505\loch\f2 ord:
+\par \hich\af2\dbch\af31505\loch\f2         Catalan
+\par \hich\af2\dbch\af31505\loch\f2         Chinese
+\par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
@@ -345,15 +321,15 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    This parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X \hich\af2\dbch\af31505\loch\f2 larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -363,28 +339,28 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Network Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Network Interface Cards
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         Start date, in MM/DD/YYYY format, for the Audit Trail report.
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date minus seven days.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?           \hich\af2\dbch\af31505\loch\f2          named
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         End date, in MM/DD/YYYY format, for the Au\hich\af2\dbch\af31505\loch\f2 dit Trail report.
+\par \hich\af2\dbch\af31505\loch\f2         End date, in MM/DD/YYYY format, for the Aud\hich\af2\dbch\af31505\loch\f2 it Trail report.
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -396,10 +372,8 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
@@ -409,16 +383,12 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par }\pard \ltrpar\s17\ql \fi720\li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15890753 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15890753\charrsid15890753 \hich\af2\dbch\af31505\loch\f2 Specifies the name of a PVS server that the PowerShell script will connect to. 
-\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15890753 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753\charrsid15890753 \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753\charrsid15890753 \hich\af2\dbch\af31505\loch\f2 Using this parameter requires the script be run from an elevated PowerShell session.
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753\charrsid15890753 \hich\af2\dbch\af31505\loch\f2 
-Starting with V4.26 of the script, this requirement is now checked.
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753\charrsid15890753 \hich\af2\dbch\af31505\loch\f2 This parameter ha
-\hich\af2\dbch\af31505\loch\f2 s an alias of AA.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753\charrsid15221399 
-\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15221399 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the name of a PVS server that \hich\af2\dbch\af31505\loch\f2 the PowerShell script will connect to.
+\par \hich\af2\dbch\af31505\loch\f2         Using this parameter requires the script be run from an elevated PowerShell session.
+\par \hich\af2\dbch\af31505\loch\f2         Starting with V4.26 of the script, this requirement is now checked.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -462,18 +432,18 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is conta\hich\af2\dbch\af31505\loch\f2 ined in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is conta\hich\af2\dbch\af31505\loch\f2 ined in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 will}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 not contain a Company Name on the cover page.
+\par \hich\af2\dbch\af31505\loch\f2         If\hich\af2\dbch\af31505\loch\f2  either registry key does not exist and this parameter is not specified, the report }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 w}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 ill}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 not contain a Company Name on the cover page.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?               \hich\af2\dbch\af31505\loch\f2      false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -481,82 +451,79 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010\hich\af2\dbch\af31505\loch\f2 , 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Valid input is:
-\par \hich\af2\dbch\af31505\loch\f2             Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Annual (Word 2010. Doesn't work wel\hich\af2\dbch\af31505\loch\f2 l for this report)
-\par \hich\af2\dbch\af31505\loch\f2             Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly works in 2010 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2             }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 but}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Subtitle/Subject & Author fields need to be moved}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 after title box is moved }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2             }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 u\hich\af2\dbch\af31505\loch\f2 p)
-\par \hich\af2\dbch\af31505\loch\f2             Banded (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Exposure (Word 2010. Works if you like looking sideways)
-\par \hich\af2\dbch\af31505\loch\f2             Facet\hich\af2\dbch\af31505\loch\f2  (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Grid (Word 2010/2013/2016. Works in 2010)
-\par \hich\af2\dbch\af31505\loch\f2             Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be manually }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2             }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2             Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be manually }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2             }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 resized or font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2             Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Motion (Word 2010/2013/\hich\af2\dbch\af31505\loch\f2 2016. Works if top date is manually changed to 36 point)
-\par \hich\af2\dbch\af31505\loch\f2             Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2             Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Puzzle (Word 2010. Top date doesn't fit; box needs to be manually resized or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2             }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 font}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2             Retrospect (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Sideline (Word 2010/201\hich\af2\dbch\af31505\loch\f2 3/2016. Doesn't work in 2013 or 2016, works in 2010)
-\par \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2             Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2             Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Tiles (Word 2010. Date doesn't fit unles\hich\af2\dbch\af31505\loch\f2 s changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2             Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             Whisp (Word 2013/2016. Works)
-\par 
+\par \tab \hich\af2\dbch\af31505\loch\f2 Valid input is:
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Alphabet (Word 2010. Works\hich\af2\dbch\af31505\loch\f2 )
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Annual (Word 2010. Doesn't work well for this report)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austere (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject & Author fields need to be moved 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 after title box is moved up)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Banded (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Conservative (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Contrast (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Cubicles (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Exposure (Word 2010. Work\hich\af2\dbch\af31505\loch\f2 s if you like looking sideways)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Facet (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Filigree (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Grid (Word 2010/2013/2016. Works in 2010)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Integral (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 manuall\hich\af2\dbch\af31505\loch\f2 y resized or font changed to 8 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 manually resized or font changed to 8 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Mod (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 3\hich\af2\dbch\af31505\loch\f2 6 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Newsprint (Word 2010. Works but date is not populated)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Perspective (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Pinstripes (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 resized or font changed to 14 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Semaphore (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 2010)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Stacks (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Transcend (Word 2010. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 ViewMaster (Word 2013/2016. Works)
+\par \tab \tab \hich\af2\dbch\af31505\loch\f2 Whisp (Word 2013/2016. Works)}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter i\hich\af2\dbch\af31505\loch\f2 s only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    na\hich\af2\dbch\af31505\loch\f2 med
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $e\hich\af2\dbch\af31505\loch\f2 nv:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF o\hich\af2\dbch\af31505\loch\f2 utput parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value             \hich\af2\dbch\af31505\loch\f2    $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -564,8 +531,8 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fal\hich\af2\dbch\af31505\loch\f2 se
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
@@ -574,57 +541,59 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the\hich\af2\dbch\af31505\loch\f2  username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    nam\hich\af2\dbch\af31505\loch\f2 ed
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, Wa\hich\af2\dbch\af31505\loch\f2 rningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVari\hich\af2\dbch\af31505\loch\f2 able, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V42.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9768283 \hich\af2\dbch\af31505\loch\f2         VERSION: 4.29}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399\charrsid15221399 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Iain\hich\af2\dbch\af31505\loch\f2  Brighton)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 December 17, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 4.292
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a \hich\af2\dbch\af31505\loch\f2 lot of help from Michael B. Smith, Jeff Wouters and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 Iain Brighton)
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: May 10, 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1
 \par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
@@ -632,58 +601,64 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1 -PDF
 \par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mic\hich\af2\dbch\af31505\loch\f2 rosoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     LocalHost for Admin\hich\af2\dbch\af31505\loch\f2 Address.
+\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1 -Hardware
 \par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 hardware.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Will use all\hich\af2\dbch\af31505\loch\f2  Default values and add additional information for each server about its }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 hardware.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PS>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CompanyName "Carl We\hich\af2\dbch\af31505\loch\f2 bster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for t\hich\af2\dbch\af31505\loch\f2 he Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PS>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -AdminAddress PVS1
 \par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mo\hich\af2\dbch\af31505\loch\f2 d" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -AdminAddress PVS1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
@@ -691,73 +666,73 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PS>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Abc123!@#
 \par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -UN "Carl W\hich\af2\dbch\af31505\loch\f2 ebster"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 Abc123!@#
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (\hich\af2\dbch\af31505\loch\f2 alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
 \par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
 \par \hich\af2\dbch\af31505\loch\f2         Abc123!@# for Password.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 7}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\PS>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -AdminAddress PVS1 -User cwebster
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     W\hich\af2\dbch\af31505\loch\f2 ill use:
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V42.ps1 \hich\af2\dbch\af31505\loch\f2 -CN "Carl Webster Consulting" -CP "Mod" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 -AdminAddress PVS1 -User cwebster
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
-\par \hich\af2\dbch\af31505\loch\f2         Script will pro\hich\af2\dbch\af31505\loch\f2 mpt for the Domain and Password
+\par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the Domain and Password
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\P\hich\af2\dbch\af31505\loch\f2 VS_Inventory_V42.ps1 -StartDate "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 " -EndDate "01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 "
 \par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE\hich\af2\dbch\af31505\loch\f2  8 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1 -StartDate "01/01/2020" -EndDate "01/31/2020"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:usern\hich\af2\dbch\af31505\loch\f2 ame = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
-\par \hich\af2\dbch\af31505\loch\f2     Will return all Audit Trail entries from "01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 " through "01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9714737 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 ".
+\par \hich\af2\dbch\af31505\loch\f2     Will return all Audit Trail entries from "01/01/2020" \hich\af2\dbch\af31505\loch\f2 through "01/31/2020".
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 ---------------------\hich\af2\dbch\af31505\loch\f2  EXAMPLE 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1 -AdminAddress PVS1 -Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \\\\\hich\af2\dbch\af31505\loch\f2 FileServer\\ShareName
 \par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1 -AdminAddress PVS1 -Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \\\\\hich\af2\dbch\af31505\loch\f2 FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mic\hich\af2\dbch\af31505\loch\f2 rosoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -765,76 +740,139 @@ Starting with V4.26 of the script, this requirement is now checked.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     PVS1 for AdminAddress.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 10}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1 -AdminAddre\hich\af2\dbch\af31505\loch\f2 ss PVS1 -SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 mail.domain.tld -From }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 
-\hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00030004007900}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid15221399\charrsid6900725 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@domain.tld -ComputerName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 DHCPServ\hich\af2\dbch\af31505\loch\f2 er01
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be \hich\af2\dbch\af31505\loch\f2 saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     PVS1 for AdminAddress.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid9196948\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid16711874 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00030b00}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid9196948\charrsid6383267 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 , }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 credentials.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -----}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 \hich\af2\dbch\af31505\loch\f2 --------------------- EXAMPLE 11}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2  --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V42.ps1 -AdminAddress PVS1 -ComputerName DHCPServer01 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 smtp.office365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 ITGroup@CarlWebster.com
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\M\hich\af2\dbch\af31505\loch\f2 icrosoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     PVS1 for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15890753 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b560000006d00610069006c0074006f003a00770065006200730074006500720040006300610072006c0077006500620073007400650072002e0063006f006d000000795881f43b1d7f48af2c825dc485276300000000
-a5ab00030000000009}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid15221399\charrsid6900725 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 
-\hich\af2\dbch\af31505\loch\f2 ending to ITGroup@carlwebster.com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9196948 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 credentials.
-\par }\pard \ltrpar\s17\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9196948 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid15221399 \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid15221399\charrsid15221399 
+\par \hich\af2\dbch\af31505\loch\f2     The\hich\af2\dbch\af31505\loch\f2  script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.t\hich\af2\dbch\af31505\loch\f2 ld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
+\par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and wi\hich\af2\dbch\af31505\loch\f2 ll not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/\hich\af2\dbch\af31505\loch\f2 
+a/answer/176600?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     account.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protection.outlook.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From SomeEmailAddress@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     -To I\hich\af2\dbch\af31505\loch\f2 TGroupDL@labaddomain.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
+"https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
+2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-applicat\hich\af2\dbch\af31505\loch\f2 
+ion-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS\hich\af2\dbch\af31505\loch\f2 _Inventory_V42.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webs\hich\af2\dbch\af31505\loch\f2 ter@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V42.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.gmail.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@g\hich\af2\dbch\af31505\loch\f2 mail.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 \hich\af2\dbch\af31505\loch\f2 RELATED LINKS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15221399\charrsid288586 
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid288586 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288586\charrsid288586 
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -954,8 +992,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000006c
-1c5900b5d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e0b6
+5d28fd26d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_V4_Script_ChangeLog.txt
+++ b/PVS_V4_Script_ChangeLog.txt
@@ -5,6 +5,17 @@
 #This script written for "Benji", March 19, 2012
 #Thanks to Michael B. Smith, Joe Shonk and Stephane Thirion for testing and fine-tuning tips 
 
+#Version 4.292 10-May-2020
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
+#	Remove the SMTP parameterset and manually verify the parameters
+#	Update Function SendEmail to handle anonymous unauthenticated email
+#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+#	Update Help Text
+
 #Version 4.291 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 


### PR DESCRIPTION
#Version 4.292 10-May-2020
#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
#	Add Receive Side Scaling setting to Function OutputNICItem
#	Change color variables $wdColorGray15 and $wdColorGray05 from [long] to [int]
#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
#	Remove the SMTP parameterset and manually verify the parameters
#	Update Function SendEmail to handle anonymous unauthenticated email
#	Update Function SetWordCellFormat to change parameter $BackgroundColor to [int]
#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
#	Update Help Text