### PR TITLE
4.32

### DIFF
--- a/PVS_Inventory_V43_ReadMe.rtf
+++ b/PVS_Inventory_V43_ReadMe.rtf
@@ -126,11 +126,11 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662
 \listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}
 {\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}{\listoverride\listid282074041\listoverridecount0\ls9}}{\*\rsidtbl \rsid288586\rsid2246377\rsid2512671\rsid2584501\rsid2585069\rsid3085909
-\rsid4090611\rsid4482658\rsid6383267\rsid6900725\rsid7282308\rsid8263315\rsid9196948\rsid9714737\rsid9768283\rsid11218240\rsid12087820\rsid12282547\rsid12849910\rsid13253201\rsid14894181\rsid15221399\rsid15890753\rsid16711874}{\mmathPr\mmathFont34
-\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2021\mo11\dy23\hr15\min3}{\version18}{\edmins116}{\nofpages12}
-{\nofwords3582}{\nofchars20423}{\nofcharsws23958}{\vern35}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid4090611\rsid4482658\rsid6383267\rsid6900725\rsid7282308\rsid7669063\rsid8263315\rsid9196948\rsid9714737\rsid9768283\rsid11218240\rsid12087820\rsid12282547\rsid12849910\rsid12869258\rsid13253201\rsid13656985\rsid14894181\rsid15221399\rsid15890753
+\rsid16711874}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2022\mo2\dy10\hr15\min28}
+{\version20}{\edmins124}{\nofpages12}{\nofwords3602}{\nofchars20534}{\nofcharsws24088}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDYyNjYzNDCyNLCwNDc3MjZV0lEKTi0uzszPAykwrgUA9zQP7iwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -206,13 +206,13 @@ http://carlwebster.com/us\hich\af37\dbch\af31505\loch\f37 ing-my-citrix-pvs-powe
 \ltrch\fcs0 \f37\fs22\insrsid13253201 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bcc00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d0070007600
 73002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000075002800
-002001004f00ff00}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/u\hich\af37\dbch\af31505\loch\f37 
-sing-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
+002001004f00ff003b00}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/\hich\af37\dbch\af31505\loch\f37 
+using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e007400610074006900
-6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000b40000429a00610000b8}}}{\fldrslt {
+6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000b40000429a00610000b85400}}}{\fldrslt {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
@@ -220,23 +220,23 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \ltrch\fcs0 \f37\fs22\insrsid4090611 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0a01000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f0076006900
 730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d0061
-006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000004000000003f46003c80}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 
+006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000004000000003f46003c80456f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 
 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\PVS_Inventory_V4}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8263315 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Th\hich\af37\dbch\af31505\loch\f37 
-e help text explains all the parameters the script accepts.
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8263315 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 T\hich\af37\dbch\af31505\loch\f37 
+he help text explains all the parameters the script accepts.
 \par \hich\af37\dbch\af31505\loch\f37 I have tested this script with PVS 5.6 SP3, PVS 6.0, PVS 6.1, PVS 7.0}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 PVS 7.1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , \hich\af37\dbch\af31505\loch\f37 PVS 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid12849910 \hich\af37\dbch\af31505\loch\f37 , and PVS 2109}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 .  I have tested the script running on and from Windows 7, Windows 8}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 \hich\af37\dbch\af31505\loch\f37 .x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 
-\hich\af37\dbch\af31505\loch\f37 Windows 10 20H2, Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server \hich\af37\dbch\af31505\loch\f37 2003 R2, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2008 R2, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 
-\hich\af37\dbch\af31505\loch\f37 Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , Windows }
-{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2012 R2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , and Windows Server 2019}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 .
+\f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 PVS 7.1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , PVS 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12849910 
+\hich\af37\dbch\af31505\loch\f37 , and PVS 2109}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 .  I have tested the script running on and from Windows 7, Windows 8}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid4090611 \hich\af37\dbch\af31505\loch\f37 .x}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 , }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 
+Windows 10 20H2, Wind\hich\af37\dbch\af31505\loch\f37 ows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2003 R2, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 
+\hich\af37\dbch\af31505\loch\f37 Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2008 R2, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 
+Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2012}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , Windows }{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Server 2012 R2}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8263315 \hich\af37\dbch\af31505\loch\f37 , and Windows Server 2019}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid2585069 .
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid15221399 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15221399 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid15221399 
 \hich\af43\dbch\af31505\loch\f43 Help Text
@@ -247,28 +247,30 @@ e help text explains all the parameters the script accepts.
 PVS_Inventory_V43.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x or 7.x farm using Microsoft Word
-\par \hich\af2\dbch\af31505\loch\f2     2010, 2013, or 2016.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 \hich\af2\dbch\af31505\loch\f2 later}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2  farm using Microsoft }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 Word}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 2010, 2013, or 2016.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \\\hich\af2\dbch\af31505\loch\f2 
 PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password <String>] [-AddDateTim\hich\af2\dbch\af31505\loch\f2 e] [-Folder <String>] [-Hardware] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password <String>] [-Add\hich\af2\dbch\af31505\loch\f2 DateTime] [-Folder <String>] [-Hardware] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-ReportFooter] [-MSWord] [-CompanyName }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer <String>] [-SmtpPort }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <Int32>] [-UseSSL]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 [-From <String>] [-To <Str\hich\af2\dbch\af31505\loch\f2 ing>] [<CommonParameters>]
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 [-From <\hich\af2\dbch\af31505\loch\f2 String>] [-To <String>] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \\\hich\af2\dbch\af31505\loch\f2 
 PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <String>] [-Password <String>] [-AddDateTime] [-Folder <String>] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid12849910 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-ReportFooter] [\hich\af2\dbch\af31505\loch\f2 
--PDF] [-CompanyName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate\hich\af2\dbch\af31505\loch\f2 
+ <DateTime>] [-ReportFooter] [-PDF] [-CompanyName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer <String>] [-SmtpPort }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 <Int32>] [-UseSSL] [-From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
@@ -276,11 +278,21 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Citrix PVS 5.x, 6.x, \hich\af2\dbch\af31505\loch\f2 or 7.x farm using Microsoft Word
-\par \hich\af2\dbch\af31505\loch\f2     and PowerShell.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word document named after the PVS 5.x, 6.x, or 7.x farm.
-\par \hich\af2\dbch\af31505\loch\f2     Document includes a Cover Page, Table of Contents, and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Version 4 and later include support for the following languag\hich\af2\dbch\af31505\loch\f2 e versions of Microsoft
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete \hich\af2\dbch\af31505\loch\f2 inventory of a Citrix PVS 5.x, 6.x, or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 \hich\af2\dbch\af31505\loch\f2 later}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2  farm using Microsoft }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 Word}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 and PowerShell.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     Creates a Word document named after the PVS 5.x, 6.x, or }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 
+\hich\af2\dbch\af31505\loch\f2 later\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 farm.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 \hich\af2\dbch\af31505\loch\f2     
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258\charrsid12869258 \hich\af2\dbch\af31505\loch\f2 This script works with any PVS version where Citrix includes support for the old }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid12869258 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258\charrsid12869258 \hich\af2\dbch\af31505\loch\f2 string-based PowerShell.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258\charrsid12849910 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     Document includes a Cover Page, Table of Contents, and Footer.
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12869258 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     Version 4 and later inclu\hich\af2\dbch\af31505\loch\f2 de support for the following language versions of Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
@@ -300,14 +312,14 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the name of a PVS server that the PowerShell script will connect to.
 \par \hich\af2\dbch\af31505\loch\f2         Using this parameter requires the script be run from an elevated PowerShell session.
-\par \hich\af2\dbch\af31505\loch\f2         Starting with V4.26 of the script, this r\hich\af2\dbch\af31505\loch\f2 equirement is now checked.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Starting with V4.26 of the script, this requirement is now checked.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Domain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the domain used for the AdminAddress connection.
@@ -321,72 +333,72 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the user used for the AdminAddress connection.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?  \hich\af2\dbch\af31505\loch\f2                   false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipe\hich\af2\dbch\af31505\loch\f2 line input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Password <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the password used for the AdminAddress connection.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the password used for the AdminAddress \hich\af2\dbch\af31505\loch\f2 connection.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Add\hich\af2\dbch\af31505\loch\f2 s a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      June 1, 2022 at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022 at 6PM is 2022-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?               \hich\af2\dbch\af31505\loch\f2      false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                   \hich\af2\dbch\af31505\loch\f2  named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer\hich\af2\dbch\af31505\loch\f2  System, Disks, Processor and
-\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
+\par \hich\af2\dbch\af31505\loch\f2         Network I\hich\af2\dbch\af31505\loch\f2 nterface Cards
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pi\hich\af2\dbch\af31505\loch\f2 peline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildca\hich\af2\dbch\af31505\loch\f2 rd characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         Start date, in MM/DD/YYYY format, for the Audit Trail report.
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date minus seven days.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         End date, in MM/DD/YYYY format, for the Audit Trail report.
+\par \hich\af2\dbch\af31505\loch\f2         End date, in MM/DD/Y\hich\af2\dbch\af31505\loch\f2 YYY format, for the Audit Trail report.
 \par \hich\af2\dbch\af31505\loch\f2         Default is today's date.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Da\hich\af2\dbch\af31505\loch\f2 te -displayhint date)
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
@@ -394,28 +406,28 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of RF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Report Footer
+\par \hich\af2\dbch\af31505\loch\f2         Report Footer
 \par \hich\af2\dbch\af31505\loch\f2                 Report information:
 \par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release Date>
 \par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
-\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local F\hich\af2\dbch\af31505\loch\f2 ormat>
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
 \par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
-\par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
+\par \hich\af2\dbch\af31505\loch\f2                         Ran from the \hich\af2\dbch\af31505\loch\f2 folder <Folder Name>
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific variables.
 \par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a cal}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2 c}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 
 \hich\af2\dbch\af31505\loch\f2 ulated value.
 \par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
-\par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
+\par \hich\af2\dbch\af31505\loch\f2         Us\hich\af2\dbch\af31505\loch\f2 ername is $env:USERNAME.
 \par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept w\hich\af2\dbch\af31505\loch\f2 ildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
@@ -423,88 +435,88 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     False
+\par \hich\af2\dbch\af31505\loch\f2         De\hich\af2\dbch\af31505\loch\f2 fault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to\hich\af2\dbch\af31505\loch\f2  10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value is contained in
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use f\hich\af2\dbch\af31505\loch\f2 or the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter h\hich\af2\dbch\af31505\loch\f2 as an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the scri\hich\af2\dbch\af31505\loch\f2 pt.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report
 \par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and\hich\af2\dbch\af31505\loch\f2  PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
-\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page t\hich\af2\dbch\af31505\loch\f2 o use.
+\par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Ann\hich\af2\dbch\af31505\loch\f2 ual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author f\hich\af2\dbch\af31505\loch\f2 ields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be mo\hich\af2\dbch\af31505\loch\f2 ved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013\hich\af2\dbch\af31505\loch\f2 /2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or\hich\af2\dbch\af31505\loch\f2  font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not \hich\af2\dbch\af31505\loch\f2 populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 R\hich\af2\dbch\af31505\loch\f2 etrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2               \hich\af2\dbch\af31505\loch\f2   Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. \hich\af2\dbch\af31505\loch\f2 Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -512,26 +524,26 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Specifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -539,15 +551,15 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Def\hich\af2\dbch\af31505\loch\f2 ault value                25
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         Default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -555,62 +567,63 @@ PVS_Inventory_V43.ps1 [-AdminAddress <String>] [-Domain <String>] [-User }{\rtlc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -To <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVari\hich\af2\dbch\af31505\loch\f2 able, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00030074}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 
+https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from thi\hich\af2\dbch\af31505\loch\f2 s script.  This script creates a Word or PDF document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Inventory_V43.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 4.31
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a l\hich\af2\dbch\af31505\loch\f2 ot of help from Michael B. Smith, Jeff Wouters, and Iain Brighton)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: November 23, 2021
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 4.3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13656985 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster (with a lot of help from Michael B. Smith, Jeff Wouters, and Iain Brighton)
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13656985 \hich\af2\dbch\af31505\loch\f2 February 1\hich\af2\dbch\af31505\loch\f2 0, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12849910\charrsid12849910 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     H\hich\af2\dbch\af31505\loch\f2 KEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:user\hich\af2\dbch\af31505\loch\f2 name = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User \hich\af2\dbch\af31505\loch\f2 Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
 \par 
 \par 
@@ -621,11 +634,11 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Comp\hich\af2\dbch\af31505\loch\f2 any="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
@@ -633,15 +646,15 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all\hich\af2\dbch\af31505\loch\f2  Default values and add additional information for each server about its
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its
 \par \hich\af2\dbch\af31505\loch\f2     hardware.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -651,13 +664,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V43.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
@@ -666,13 +679,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V43.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V43.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster \hich\af2\dbch\af31505\loch\f2 for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par 
 \par 
@@ -681,16 +694,16 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V43.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1 -User cwebster -Domain WebstersLab -Password
-\par \hich\af2\dbch\af31505\loch\f2     Abc\hich\af2\dbch\af31505\loch\f2 123!@#
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAd\hich\af2\dbch\af31505\loch\f2 dress PVS1 -User cwebster -Domain WebstersLab -Password
+\par \hich\af2\dbch\af31505\loch\f2     Abc123!@#
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
-\par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
-\par \hich\af2\dbch\af31505\loch\f2         We\hich\af2\dbch\af31505\loch\f2 bstersLab for Domain.
+\par \hich\af2\dbch\af31505\loch\f2         WebstersLab for Domain.
 \par \hich\af2\dbch\af31505\loch\f2         Abc123!@# for Password.
 \par 
 \par 
@@ -698,13 +711,13 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\PVS_Inventory_V43.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 PVS_Inventory_V43.ps1 -CN "Carl Webster Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -AdminAddress PVS1 -User cwebster
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Pa\hich\af2\dbch\af31505\loch\f2 ge format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         PVS1 for AdminAddress.
 \par \hich\af2\dbch\af31505\loch\f2         cwebster for User.
 \par \hich\af2\dbch\af31505\loch\f2         Script will prompt for the Domain and Password
@@ -714,14 +727,14 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1 -StartDate "01/01/2022" -EndDate "01/31/2022"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS\hich\af2\dbch\af31505\loch\f2 _Inventory_V43.ps1 -StartDate "01/01/2022" -EndDate "01/31/2022"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par \hich\af2\dbch\af31505\loch\f2     Admi\hich\af2\dbch\af31505\loch\f2 nAddress = LocalHost
+\par \hich\af2\dbch\af31505\loch\f2     AdminAddress = LocalHost
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Ca\hich\af2\dbch\af31505\loch\f2 rl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
@@ -783,88 +796,88 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
-"https://support.google.com/a/answer/2956491?hl=en"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12849910 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030064}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12849910 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910\charrsid12849910 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email u\hich\af2\dbch\af31505\loch\f2 sing a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The scrip\hich\af2\dbch\af31505\loch\f2 t generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12849910\charrsid12849910 
-\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlo\hich\af2\dbch\af31505\loch\f2 ok.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-o\hich\af2\dbch\af31505\loch\f2 ffice-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid12849910 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-\hich\af2\dbch\af31505\loch\f2 send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 
-https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003b}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid12849910\charrsid12849910 \hich\af2\dbch\af31505\loch\f2 https://d\hich\af2\dbch\af31505\loch\f2 
+ocs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12849910\charrsid12849910 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The s\hich\af2\dbch\af31505\loch\f2 cript uses the default SMTP port 25 and SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12849910\charrsid12849910 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To I\hich\af2\dbch\af31505\loch\f2 TGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.c\hich\af2\dbch\af31505\loch\f2 om on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the scr\hich\af2\dbch\af31505\loch\f2 ipt prompts the
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the script prompts the
 \par \hich\af2\dbch\af31505\loch\f2     user to enter valid credentials.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Inventory_V43.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12849910 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid12849910\charrsid12849910 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the\hich\af2\dbch\af31505\loch\f2  "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gma\hich\af2\dbch\af31505\loch\f2 il or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credential\hich\af2\dbch\af31505\loch\f2 s are not valid to send email, the script prompts the
-\par \hich\af2\dbch\af31505\loch\f2     user to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the script prompts the
+\par \hich\af2\dbch\af31505\loch\f2     user to enter \hich\af2\dbch\af31505\loch\f2 valid credentials.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -987,8 +1000,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000d079
-ad82ade0d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000030db
+3d17c51ed801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_V4_Script_ChangeLog.txt
+++ b/PVS_V4_Script_ChangeLog.txt
@@ -5,6 +5,19 @@
 #This script written for "Benji", March 19, 2012
 #Thanks to Michael B. Smith, Joe Shonk and Stephane Thirion for testing and fine-tuning tips 
 
+#Version 4.32 10-Feb-2022
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 4.31 23-Nov-2021
 #	Added Function OutputReportFooter
 #	Added Parameter ReportFooter

--- a/README.md
+++ b/README.md
@@ -2,5 +2,28 @@
 Citrix Provisioning Services (PVS) Old
 
 Old String-Based Provisioning Services (PVS) Documentation Script
-Supports PVS versions 5.6 through 7.6
-Supports Remoting
+
+    Creates a complete inventory of a Citrix PVS 5.x, 6.x, or later farm using Microsoft 
+    Word and PowerShell.
+
+    Creates a Word document named after the PVS 5.x, 6.x, or later farm.
+    
+    This script works with any PVS version where Citrix includes support for the old 
+    string-based PowerShell.
+
+    Document includes a Cover Page, Table of Contents, and Footer.
+
+    Version 4 and later include support for the following language versions of Microsoft
+    Word:
+        Catalan
+        Chinese
+        Danish
+        Dutch
+        English
+        Finnish
+        French
+        German
+        Norwegian
+        Portuguese
+        Spanish
+        Swedish


### PR DESCRIPTION
#Version 4.32 10-Feb-2022
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file
